### PR TITLE
client's secret should be invalid if not sent.

### DIFF
--- a/src/Bridge/Repository/ClientRepository.php
+++ b/src/Bridge/Repository/ClientRepository.php
@@ -43,9 +43,7 @@ class ClientRepository implements ClientRepositoryInterface
         $conditions = [
             $this->table->getPrimaryKey() => $clientIdentifier,
         ];
-        if ($clientSecret !== null) {
-            $conditions[$this->table->aliasField('client_secret')] = $clientSecret;
-        }
+        $conditions[$this->table->aliasField('client_secret')] = (string)$clientSecret;
 
         $client = $this->table->find()->where($conditions)->first();
         /* @var $client Client|null */

--- a/tests/Fixture/ClientsFixture.php
+++ b/tests/Fixture/ClientsFixture.php
@@ -52,6 +52,18 @@ class ClientsFixture extends TestFixture
             ]),
         ];
 
+        $this->records[] = [
+            'id' => 'Public',
+            'client_secret' => '',
+            'name' => 'Public Client',
+            'redirect_uri' => json_encode(['http://www.example.com']),
+            'grant_types' => json_encode([
+                'password',
+                'authorization_code',
+                'refresh_token',
+            ]),
+        ];
+
         parent::init();
     }
 }

--- a/tests/TestCase/Bridge/Repository/ClientRepositoryTest.php
+++ b/tests/TestCase/Bridge/Repository/ClientRepositoryTest.php
@@ -50,15 +50,19 @@ class ClientRepositoryTest extends TestCase
     public function dataValidateClient()
     {
         return [
-            'valid: Client id only' => [
-                ['TEST', null, null],
+            'valid: Public Client id only' => [
+                ['Public', null, null],
                 true,
+            ],
+            'invalid: Confidential Client id only' => [
+                ['TEST', null, null],
+                false,
             ],
             'valid: Client id with secret' => [
                 ['TEST', 'TestSecret', null],
                 true,
             ],
-            'invalid: Client id only' => [
+            'invalid: Unregistered Client id only' => [
                 ['INVALID', null, null],
                 false,
             ],


### PR DESCRIPTION
Confidential clients MUST always authenticate.
Clients with non-empty secrets are confidential.
Only clients with empty secrets are allowed not to send secret.