### PR TITLE
Use config for field to get user identifier at authorization endpoint.

### DIFF
--- a/src/Bridge/Repository/UserRepository.php
+++ b/src/Bridge/Repository/UserRepository.php
@@ -40,7 +40,7 @@ class UserRepository implements UserRepositoryInterface
     ) {
         $user = $this->finder->findUser($username, $password);
 
-        return $user ? new User($user->get($this->finder->getUserIdentityPath())) : null;
+        return $user ? new User($this->finder->getUserIdentifier($user)) : null;
     }
 
     /**

--- a/src/Bridge/UserFinderByUserCredentialsInterface.php
+++ b/src/Bridge/UserFinderByUserCredentialsInterface.php
@@ -17,6 +17,14 @@ interface UserFinderByUserCredentialsInterface
     public function findUser($username, $password): ?EntityInterface;
 
     /**
+     * Get the user identifier from authentication identity data.
+     *
+     * @param \ArrayAccess|array $identityData Authentication identity data
+     * @return string|int|null
+     */
+    public function getUserIdentifier($identityData);
+
+    /**
      * Get Users repository identity path
      *
      * @return string

--- a/src/Bridge/UserFinderByUserCredentialsInterface.php
+++ b/src/Bridge/UserFinderByUserCredentialsInterface.php
@@ -23,11 +23,4 @@ interface UserFinderByUserCredentialsInterface
      * @return string|int|null
      */
     public function getUserIdentifier($identityData);
-
-    /**
-     * Get Users repository identity path
-     *
-     * @return string
-     */
-    public function getUserIdentityPath();
 }

--- a/src/Controller/Component/OAuthComponent.php
+++ b/src/Controller/Component/OAuthComponent.php
@@ -152,15 +152,7 @@ class OAuthComponent extends Component implements UserFinderByUserCredentialsInt
      */
     public function getUserIdentifier($identityData)
     {
-        return $identityData[$this->getUserIdentityPath()];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getUserIdentityPath()
-    {
-        return $this->getConfig('userIdentityPath');
+        return $identityData[$this->getConfig('userIdentityPath')];
     }
 
     /**

--- a/src/Controller/Component/OAuthComponent.php
+++ b/src/Controller/Component/OAuthComponent.php
@@ -42,7 +42,7 @@ class OAuthComponent extends Component implements UserFinderByUserCredentialsInt
             'Password',
         ],
         'passwordAuthenticator' => 'Form',
-        'userIdentityPath' => 'id',
+        'userIdentifierField' => 'id',
         'privateKey' => null,
         'encryptionKey' => null,
         'accessTokenTTL' => 'PT1H',
@@ -152,7 +152,7 @@ class OAuthComponent extends Component implements UserFinderByUserCredentialsInt
      */
     public function getUserIdentifier($identityData)
     {
-        return $identityData[$this->getConfig('userIdentityPath')];
+        return $identityData[$this->getConfig('userIdentifierField')];
     }
 
     /**

--- a/src/Controller/Component/OAuthComponent.php
+++ b/src/Controller/Component/OAuthComponent.php
@@ -150,6 +150,14 @@ class OAuthComponent extends Component implements UserFinderByUserCredentialsInt
     /**
      * @inheritDoc
      */
+    public function getUserIdentifier($identityData)
+    {
+        return $identityData[$this->getUserIdentityPath()];
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getUserIdentityPath()
     {
         return $this->getConfig('userIdentityPath');

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -96,7 +96,7 @@ class OAuthController extends AppController
 
             $this->dispatchEvent('OAuthServer.beforeAuthorize', [$authRequest]);
 
-            $userId = $this->Authentication->getIdentity()->getIdentifier();
+            $userId = $this->Authentication->getIdentityData($this->OAuth->getUserIdentityPath());
             if ($userId) {
                 $authRequest->setUser(new User($userId));
             }

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -96,7 +96,7 @@ class OAuthController extends AppController
 
             $this->dispatchEvent('OAuthServer.beforeAuthorize', [$authRequest]);
 
-            $userId = $this->Authentication->getIdentityData($this->OAuth->getUserIdentityPath());
+            $userId = $this->Authentication->getIdentity()->getOriginalData()[$this->OAuth->getUserIdentityPath()];
             if ($userId) {
                 $authRequest->setUser(new User($userId));
             }

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -96,7 +96,7 @@ class OAuthController extends AppController
 
             $this->dispatchEvent('OAuthServer.beforeAuthorize', [$authRequest]);
 
-            $userId = $this->Authentication->getIdentity()->getOriginalData()[$this->OAuth->getUserIdentityPath()];
+            $userId = $this->OAuth->getUserIdentifier($this->Authentication->getIdentity()->getOriginalData());
             if ($userId) {
                 $authRequest->setUser(new User($userId));
             }

--- a/tests/TestCase/Bridge/Repository/UserRepositoryTest.php
+++ b/tests/TestCase/Bridge/Repository/UserRepositoryTest.php
@@ -50,8 +50,10 @@ class UserRepositoryTest extends TestCase
 
         $this->finder
             ->expects($this->once())
-            ->method('getUserIdentityPath')
-            ->willReturn('id');
+            ->method('getUserIdentifier')
+            ->willReturnCallback(function ($identityData) {
+                return $identityData['id'];
+            });
 
         $result = $this->repository->getUserEntityByUserCredentials($username, $password, $grantType, $client);
 

--- a/tests/TestCase/Controller/Component/OAuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/OAuthComponentTest.php
@@ -8,6 +8,7 @@ use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
+use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use League\OAuth2\Server\AuthorizationServer;
 use OAuthServer\Controller\Component\OAuthComponent;
@@ -76,9 +77,9 @@ class OAuthComponentTest extends TestCase
         $this->assertSame(['Password', 'RefreshToken'], $component->getConfig('supportedGrants'));
     }
 
-    public function testGetUserIdentityPath()
+    public function testGetUserIdentifier()
     {
-        $this->assertSame('id', $this->component->getUserIdentityPath());
+        $this->assertSame('user1', $this->component->getUserIdentifier(new Entity(['id' => 'user1'])));
     }
 
     public function testFindUser()


### PR DESCRIPTION
The config has been used for the resource owner password credentials grant type.
The same field should be referred for other grant types using the authorization endpoint.

Rename config key properly because it never be "path".
Replace interface method.
